### PR TITLE
I added the i18n support.

### DIFF
--- a/classes/kohana/kostache.php
+++ b/classes/kohana/kostache.php
@@ -268,4 +268,17 @@ abstract class Kohana_Kostache {
 		return $template;
 	}
 
+	/**
+	 * I18n callback that translates the text.
+	 * 
+	 * Example of how to translate text in your template by using Kohana's I18n:
+	 * <div>{{#i18n}}Email{{/i18n}}</div>
+	 * 
+	 * @return  array
+	 */
+	public function i18n()
+	{
+		return array('I18n', 'get');
+	}
+
 }


### PR DESCRIPTION
Normally you can translate the text inside your View_Something class and include that text in your template by using variables. But I find it useful to write the text right in the template and translate it from there. Otherways there are too many variables that actually doesn't get used anywhere else.

An example of how to translate the text in templates:

``` html
<div>{{#i18n}}Email{{/i18n}}</div>
```
