### PR TITLE
Throw Kohana_Exception when Mustache template file not found

### DIFF
--- a/classes/Mustache/Loader/Kohana.php
+++ b/classes/Mustache/Loader/Kohana.php
@@ -30,6 +30,12 @@ class Mustache_Loader_Kohana implements Mustache_Loader, Mustache_Loader_Mutable
 	protected function _load_file($name)
 	{
 		$filename = Kohana::find_file($this->_base_dir, $name, $this->_extension);
+
+		if ( ! $filename)
+		{
+			throw new Kohana_Exception('Mustache template ":name" not found', array(':name' => $name));
+		}
+
 		return file_get_contents($filename);
 	}
 


### PR DESCRIPTION
Was trying to use the module for the first time and ran into `ErrorException [ Warning ]: file_get_contents(): Filename cannot be empty`. Thought that throwing an exception with the path would be more informative <del>(and catchable?)</del>.
