### PR TITLE
Don't use an anonymous function for the escape option

### DIFF
--- a/classes/Kohana/Kostache.php
+++ b/classes/Kohana/Kostache.php
@@ -20,9 +20,7 @@ class Kohana_Kostache {
 			array(
 				'loader' => new Mustache_Loader_Kohana(),
 				'partials_loader' => new Mustache_Loader_Kohana('templates/partials'),
-				'escape' => function($value) {
-					return HTML::chars($value);
-				},
+				'escape' => array('HTML', 'chars'),
 				'cache' => APPPATH.'cache/mustache',
 			)
 		);


### PR DESCRIPTION
The escape option must be of type `callable`, since the anonymous function was just calling the `HTML::chars` method we can instead just pass an array representing this method and it will be seen as a callable type

See: http://php.net/manual/en/language.types.callable.php
