### PR TITLE
add Composer support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.swp
+/vendor/
+/composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+	"name": "zombor/kostache",
+	"type": "kohana-module",
+	"description": "Logic-less View/Mustache Module for Kohana v3",
+	"keywords": ["kohana","mustache","templating"],
+	"homepage": "https://github.com/zombor/KOstache",
+	"license": "MIT",
+	"authors": [
+		{
+			"name": "Jeremy Bush",
+			"email": "contractfrombelow@gmail.com"
+		}
+	],
+	"require": {
+		"mustache/mustache": "~2.0.2",
+		"php": ">=5.3.0",
+		"composer/installers": "*"
+	}
+}

--- a/init.php
+++ b/init.php
@@ -1,5 +1,7 @@
 <?php defined('SYSPATH') or die('No direct script access.');
 
 // Load Mustache for PHP
-include Kohana::find_file('vendor', 'mustache/src/Mustache/Autoloader');
-Mustache_Autoloader::register();
+if ( ! class_exists('Mustache_Engine')) {
+	include Kohana::find_file('vendor', 'mustache/src/Mustache/Autoloader');
+	Mustache_Autoloader::register();
+}


### PR DESCRIPTION
I added Composer support. The package just needs to be registered on [Packagist](https://packagist.org/).

I removed the submodule for Mustache.php and added it as a Composer dependency. I also deleted the autoloader for Mustache.php because this is handled by Composer.

Fixes #52.
