### PR TITLE
Uses the proper Kohana cache directory.

### DIFF
--- a/classes/Kohana/Kostache.php
+++ b/classes/Kohana/Kostache.php
@@ -23,7 +23,7 @@ class Kohana_Kostache {
 				'escape' => function($value) {
 					return HTML::chars($value);
 				},
-				'cache' => APPPATH.'cache/mustache',
+				'cache' => Kohana::$cache_dir.DIRECTORY_SEPARATOR.'mustache',
 			)
 		);
 


### PR DESCRIPTION
The previous implementation assumed that the cache dir is in the default location. With this patch, the mustache cache dir will follow wherever you set the Kohana cache_dir in bootstrap.php using the Kohana::init() method.
